### PR TITLE
Force DOM refresh to fix pagination issue

### DIFF
--- a/linker.js
+++ b/linker.js
@@ -85,3 +85,8 @@ $(".description bdi").hover(function() {
 		var info = gdinfo(element, cleanname);
 	}
 });
+
+/* Force DOM to refresh when new page is clicked */
+$(".pagination a").click(function() {
+	window.location.reload();
+});


### PR DESCRIPTION
The DOM changes when a new page button is clicked, but the page doesn't refresh so the script doesn't affect the new DOM elements. Forced a page refresh to fix